### PR TITLE
Manually add skills, extra certifications

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-RACK_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 npm-debug.log
 .DS_Store
 .rubocop.yml
+.env

--- a/jekyll/_includes/site/jobpostingtemplate.html
+++ b/jekyll/_includes/site/jobpostingtemplate.html
@@ -41,6 +41,13 @@
   </ul>
 {/preferredSkills.length}
 
+{#certificationsNeeded.length}
+  <h5>Certifcations Needed</h5>
+  <ul>
+    {#certificationsNeeded}<li>{name}</li>{/certificationsNeeded}
+  </ul>
+{/certificationsNeeded.length}
+
 {#trainingOffered}
   <br><strong>Training Offered:</strong> {trainingOffered}
 {/trainingOffered}

--- a/jekyll/_includes/site/skillstemplates.html
+++ b/jekyll/_includes/site/skillstemplates.html
@@ -11,7 +11,7 @@
           {>skillAdder}
         </li>
     </ul>
-    <span class="circle circle-plus">+</span>
+    <span class="circle circle-plus" data-control="addSkillsButton" id="add-{id}">+</span>
   {/skills.length}
 </script>
 
@@ -31,7 +31,7 @@
 
 <script type="text/x-template" data-template="skillAdder">
   <form>
-      <fieldset class="switch-field">
+      <fieldset class="switch-field add-skill">
           <input type="radio" id="switch-center-add-{id}" name="switch-add-{id}" value="preferred" checked/>
           <label for="switch-center-add-{id}">Preferred</label>
           <input type="radio" id="switch-right-add-{id}" name="switch-add-{id}" value="required" />

--- a/jekyll/_includes/site/skillstemplates.html
+++ b/jekyll/_includes/site/skillstemplates.html
@@ -38,5 +38,5 @@
           <label for="switch-right-add-{id}">Required</label>
       </fieldset>
   </form>
-  <input type="text" id="switch-add-input-{id}" name="switch-add-{id}">
+  <input type="text" name="switch-add-{id}" class="new-skill">
 </script>

--- a/jekyll/asset/script/main.js
+++ b/jekyll/asset/script/main.js
@@ -365,7 +365,6 @@
     }
 
     function duplicateCertControl(element) {
-
       var original = $('#cert-needed')[0];
       var i = 1;
 
@@ -373,6 +372,18 @@
         var clone = original.cloneNode(true);
         clone.id = original.id + i++;
         $(clone).insertBefore('#add-cert');
+      });
+    }
+
+    function duplicateSkillControl(element) {
+      var divId = $("div #" + element.id).parent("div")[0].id;
+      var i = 1;
+
+      $(element).bind('click', function() {
+        console.log("clicked skillz button for " + divId);
+        var newHTML = templates.skillAdder.render({id: divId + i++});
+        $("#" + divId + " ul")
+          .append($("<li>").append(newHTML));
       });
     }
 
@@ -433,6 +444,7 @@
       postingData.preferredSkills = preferredSkills;
 
       // Also include Certs
+      // var certsEl = $("input")
 
       var trainingOfferedEl = $("input:radio[name=training]:checked");
       if(trainingOfferedEl) postingData.trainingOffered = trainingOfferedEl.val();
@@ -447,7 +459,10 @@
         skills: skills
       };
 
-      $("#" + id)[0].innerHTML = templates.skillSet.render(skillSet, templates);
+      var element = $("#" + id)[0];
+      element.innerHTML = templates.skillSet.render(skillSet, templates);
+      cuff.controls.addSkillsButton = duplicateSkillControl;
+      cuff(element);          
     }
 
     function generateLintId (results) {

--- a/jekyll/asset/script/main.js
+++ b/jekyll/asset/script/main.js
@@ -371,6 +371,7 @@
       $(element).bind('click', function() {
         var clone = original.cloneNode(true);
         clone.id = original.id + i++;
+        clone.value = "";
         $(clone).insertBefore('#add-cert');
       });
     }
@@ -380,7 +381,6 @@
       var i = 1;
 
       $(element).bind('click', function() {
-        console.log("clicked skillz button for " + divId);
         var newHTML = templates.skillAdder.render({id: divId + i++});
         $("#" + divId + " ul")
           .append($("<li>").append(newHTML));
@@ -418,6 +418,7 @@
 
       var requiredSkills = [];
       var preferredSkills = [];
+      collectAddedSkills();
       _.forOwn(currentSkillSet, function(skillName, skillId) {
         var skillSwitchEl = $("input:radio[name=switch-" + skillId + "]:checked");
         if(skillSwitchEl) {
@@ -443,13 +444,27 @@
       postingData.requiredSkills = requiredSkills;
       postingData.preferredSkills = preferredSkills;
 
-      // Also include Certs
-      // var certsEl = $("input")
+      var certificationsNeeded = [];
+      $('input[name=certNeeded]').each(function() {
+        if(this.value) {
+          certificationsNeeded.push({name: this.value});
+        }
+      });
+      postingData.certificationsNeeded = certificationsNeeded;
 
       var trainingOfferedEl = $("input:radio[name=training]:checked");
       if(trainingOfferedEl) postingData.trainingOffered = trainingOfferedEl.val();
 
       return templates.fullJobPosting.render(postingData, templates);
+    }
+
+    function collectAddedSkills() {
+      $('form + input').each(function(){
+        if (this.value) {
+          var id = this.name.substring(7, this.name.length);
+          currentSkillSet[id] = this.value;
+        }
+      });
     }
 
     function renderSkillSet(name, skills, id) {

--- a/jekyll/asset/script/main.js
+++ b/jekyll/asset/script/main.js
@@ -41,6 +41,7 @@
         cuff.controls.gotoPage1Button = gotoPage1Control;
         cuff.controls.gotoPage2Button = gotoPage2Control;
         cuff.controls.exportPostingPageButton = exportPostingPageControl;
+        cuff.controls.addCertButton = duplicateCertControl;
         cuff();
     }
 
@@ -360,6 +361,18 @@
             renderSkillSet("Hard Skills", tools, "hard-skills");
           }
         }
+      });
+    }
+
+    function duplicateCertControl(element) {
+
+      var original = $('#cert-needed')[0];
+      var i = 1;
+
+      $(element).bind('click', function() {
+        var clone = original.cloneNode(true);
+        clone.id = original.id + i++;
+        $(clone).insertBefore('#add-cert');
       });
     }
 

--- a/jekyll/asset/script/main.js
+++ b/jekyll/asset/script/main.js
@@ -42,6 +42,7 @@
         cuff.controls.gotoPage2Button = gotoPage2Control;
         cuff.controls.exportPostingPageButton = exportPostingPageControl;
         cuff.controls.addCertButton = duplicateCertControl;
+        cuff.controls.addSkillsButton = duplicateSkillControl;
         cuff();
     }
 
@@ -459,7 +460,7 @@
     }
 
     function collectAddedSkills() {
-      $('form + input').each(function(){
+      $('input.new-skill').each(function(){
         if (this.value) {
           var id = this.name.substring(7, this.name.length);
           currentSkillSet[id] = this.value;
@@ -476,7 +477,6 @@
 
       var element = $("#" + id)[0];
       element.innerHTML = templates.skillSet.render(skillSet, templates);
-      cuff.controls.addSkillsButton = duplicateSkillControl;
       cuff(element);          
     }
 

--- a/jekyll/asset/style/main.scss
+++ b/jekyll/asset/style/main.scss
@@ -185,6 +185,7 @@ footer p{
     width: 96%;
     padding: 2%;
     font-size:1.6rem;
+    margin-bottom: 5px;
 }
 .line-input select{
     width: 250px;
@@ -474,16 +475,20 @@ footer p{
     transition:         all 0.2s ease-in-out;
 }
 .skillsNext:first-child { margin-left: 0px; }
-.skillsNext:hover{background-color:#D1D1D1;}
-.skillsEngine{width: 840px; margin: 0 auto;}
-.skillsEngine h4{text-align: center;}
-.skillsEngine h4:last-of-type{margin: 50px 0 0 0;}
-.skillsEngine p{float:left; padding: 10px 0 0;}
-.skillsEngine p.centered{float:none; padding: 0;}
-.skillsEngine ul{list-style-type: none;}
-.skillsEngine input{margin: 10px 0 0;}
-.skillsEngine ul li{width:500px; margin: 0 auto;}
-.skillsEngine ul li:last-of-type fieldset{margin-left:110px;}
+.skillsNext:hover {background-color:#D1D1D1;}
+.skillsEngine {width: 840px; margin: 0 auto;}
+.skillsEngine h4  {text-align: center;}
+.skillsEngine h4:last-of-type {margin: 50px 0 0 0;}
+.skillsEngine p {float:left; padding: 10px 0 0;}
+.skillsEngine p.centered {float:none; padding: 0;}
+.skillsEngine ul {list-style-type: none;}
+.skillsEngine input {margin: 10px 0 0;}
+.skillsEngine ul li {
+    width:500px; 
+    margin: 0 auto; 
+    overflow: hidden;
+}
+.skillsEngine ul li fieldset.add-skill {margin-left:110px;}
 .switch-field {
     margin: 0 20px 0;
     float: left;

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -68,7 +68,7 @@ layout: page
 
   <div class="skillsEngine">
       <h3>Soft and Hard Skills</h3>
-      <p class="centered">These are common skills associated with the title and description of your position.</br>Please select, N/A, Preferred or Required for each skill listed. You may also add a skill that is not listed.</p>
+      <p class="centered">These are common skills associated with the title and description of your position.<br/>Please select N/A, Preferred or Required for each skill listed. You may also add a skill that is not listed.</p>
 
       {% include site/skillstemplates.html %}
 
@@ -77,11 +77,11 @@ layout: page
 
   </div>
 
-  <div class="line-input" id="certificated_needed">
+  <div class="line-input" id="certificates-needed">
       <h3>Are any certificates needed?</h3>
       <form>
-          <input type="text" id="certNeeded" name="certNeeded">
-          <span class="circle circle-plus">+</span>
+          <input type="text" id="cert-needed" name="certNeeded">
+          <span class="circle circle-plus" id="add-cert" data-control="addCertButton">+</span>
       </form>
   </div>
 

--- a/sinatra/sinatra_app.rb
+++ b/sinatra/sinatra_app.rb
@@ -1,5 +1,5 @@
-set :public_dir, Proc.new { File.join(root, "_site") }
-set :views, Proc.new { File.join(File.dirname(__FILE__), "views") }
+set :public_dir, proc { File.join(root, '_site') }
+set :views, proc { File.join(File.dirname(__FILE__), 'views') }
 enable :sessions
 set :session_secret, ENV['SINATRA_SESSION_SECRET']
 
@@ -21,20 +21,17 @@ post '/api/skillsengine/competencies' do
 end
 
 before do
-    response.headers['Cache-Control'] = 'public, max-age=36000'
+  response.headers['Cache-Control'] = 'public, max-age=36000'
 end
 
 # remove all trailing slashes
 get %r{(/.*)\/$} do
-  redirect "#{params[:captures].first}"
+  redirect params[:captures].first.to_s
 end
 
 # serve the jekyll site from the _site folder
 get '/*' do
-    file_name = "_site#{request.path_info}/index.html".gsub(%r{\/+},'/')
-    if File.exists?(file_name)
+  file_name = "_site#{request.path_info}/index.html".gsub(%r{\/+}, '/')
+  raise Sinatra::NotFound unless File.exist?(file_name)
   File.read(file_name)
-    else
-  raise Sinatra::NotFound
-    end
 end


### PR DESCRIPTION
➕  button works to add a duplicate of the existing input box for both skills categories and certifications. Renders added skills & certifications on the "export" page. If the box is empty, nothing is exported, i.e. no empty bullet point. Also ruby code cleanup/yak-shaving, see that commit for details.

Styling is passable. Fixes #46
