### PR TITLE
Added reset button & regenerate button #58

### DIFF
--- a/jekyll/asset/script/main.js
+++ b/jekyll/asset/script/main.js
@@ -4,7 +4,7 @@
     var templates = {};
     var acceptedTypes = ["tech", "sexism", "realism"];
     var currentSkillsAnalysis = {};
-    var pages = ['1', '2', '3'];
+    var pages = ['1', '2'];
 
     if (!isSupportedBrowser()) {
         document.getElementById('unsupported').style.display = 'block';
@@ -37,6 +37,7 @@
         cuff.controls.loadSkillsButton = loadSkillsControl;
         cuff.controls.gotoPage1Button = gotoPage1Control;
         cuff.controls.exportPostingPageButton = exportPostingPageControl;
+        cuff.controls.startOverButton = startOverControl;
         cuff.controls.addCertButton = duplicateCertControl;
         cuff.controls.addSkillsButton = duplicateSkillControl;
         cuff.controls.removeSkillButton = removeSkillControl;
@@ -210,11 +211,24 @@
     }
 
     function loadSkillsControl(element) {
-      $(element).bind('click', function() {
+      var $generateButton = $(element);
+      $generateButton.bind('click', function() {
         generateSkillsControl();
-        renderCertification("cert");
+        if ( $generateButton.hasClass('generate') ) { // i.e. we're not *re*generating
+          renderCertification("cert");
+        }
         $(".skillsEngine, #qualificationsNeeded, #exportButton").fadeIn();
-        $("#generateSkills").hide();
+        $("#generateSkills").addClass('regenerate').removeClass('generate').text('Regenerate Skills');
+      });
+    }
+
+    function startOverControl(element) {
+      $(element).bind('click', function() {
+        currentSkillSet = {}; // clear skills data just in case user tries to export
+        $("#job-desc-input").val('').trigger('keyup'); // keyup triggers clearing right-hand results box
+        $("[name=positiontitle]").val('');
+        $(".skillsEngine, #qualificationsNeeded, #exportButton").fadeOut();
+        $("#generateSkills").addClass('generate').removeClass('regenerate').text('Generate Skills');
       });
     }
 
@@ -378,15 +392,15 @@
         skills: skills
       };
 
-      var element = $("#" + id)[0];
-      element.innerHTML = templates.skillSet.render(skillSet, templates);
-      cuff(element);
+      var $element = $("#" + id)[0];
+      $element.innerHTML = templates.skillSet.render(skillSet, templates);
+      cuff($element);
     }
 
     function renderCertification(id) {
-      var certList = $('#cert-list');
-      certList.append(templates.certNeeded.render({"id": id}));
-      cuff(certList[0]);
+      var $certList = $('#cert-list');
+      $certList.append(templates.certNeeded.render({"id": id}));
+      cuff($certList[0]);
     }
 
     function generateLintId (results) {

--- a/jekyll/asset/style/main.scss
+++ b/jekyll/asset/style/main.scss
@@ -150,7 +150,7 @@ button {
     background-color: #fff;
     border: 5px solid $darkGrey;
     padding:15px;
-    display: block;
+    display: inline-block;
     &:hover{ background-color: $darkGrey; color: #fff; }
 }
 

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -25,7 +25,7 @@ layout: page
     <p>To see common skills associated with the title and description you've provided for this position, click the Generate Skills button below. Then select "Preferred" or "Required" for each skill. You may also add a skill that is not listed.</p>
     <p><em>Powered by <a href="https://skillsengine.com/home">SkillsEngine</a></em></p>
 
-    <button data-control="loadSkillsButton" id="generateSkills">Generate Skills</button>
+    <button data-control="loadSkillsButton" id="generateSkills" class="generate">Generate Skills</button>
     <div class="skillsEngine">
       {% include site/skillstemplates.html %}
       <div id="skills-and-tools"></div>
@@ -49,6 +49,7 @@ layout: page
   </section>
 
   <section id="exportButton">
+    <button data-control="startOverButton">START OVER</button>
     <button data-control="exportPostingPageButton">EXPORT</button>
   </section>
 </div>


### PR DESCRIPTION
Mark & I picked this to pair on this morning, so here it is! Since we did this without discussion over I'd really like feedback on it (or at least a :shipit: from everyone).

Change one: allow regenerate of the skills section (basically call the API again)
![screenshot 2016-05-20 14 04 18](https://cloud.githubusercontent.com/assets/1650720/15442110/d21d0b7a-1e93-11e6-808e-562a87a99266.png)
After you click "Generate Skills" it changes to "Regenerate Skills", which does exactly what you think it does. It will overwrite anything that's been done in the skills section, like user-added skills. The Qualifications section isn't affected.

Change two: reset everything
![screenshot 2016-05-20 14 06 43](https://cloud.githubusercontent.com/assets/1650720/15442155/1b19ce12-1e94-11e6-9fac-04e5ca8a1cbd.png)
Added the "Start Over" button. It resets everything, including the job description text. Doesn't scroll it back to the top though, dunno if that's important.
