### PR TITLE
remove export button in safari

### DIFF
--- a/jekyll/asset/script/main.js
+++ b/jekyll/asset/script/main.js
@@ -206,6 +206,10 @@
         var content = composePostingFromFields();
         $("#final-posting")[0].innerHTML = content;
         showPage('3');
+        if (navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1) {
+          $(".word-doc").hide();
+          $(".word-doc-width").css("width", "80px");
+        }
         convertedDocument = htmlDocx.asBlob(content);
       });
     }

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -90,15 +90,15 @@ layout: page
 
 <div id="page_3" style="display:none;">
   <div class="centered">
-    <section>
+    <section class="word-doc">
       <button data-control="saveAsWordDocButton" data-event-category="navigate" data-event-action="save as word doc">Save as Word Document</button>
     </section>
     <section id="final-posting"></section>
 
     <section id="saveButtonContainer">
-      <div class="centered">
+      <div class="centered word-doc-width">
         <button data-control="gotoPage2Button" data-event-category="navigate" data-event-action="back">Back</button>
-        <button data-control="saveAsWordDocButton" data-event-category="navigate" data-event-action="save as word doc">Save as Word Document</button>
+        <button data-control="saveAsWordDocButton" data-event-category="navigate" data-event-action="save as word doc" class="word-doc">Save as Word Document</button>
       </div>
     </section>
   </div>


### PR DESCRIPTION
In safari, this removes the save as word doc button. It also fiddles with the width of the container. I think this is probably fine, but if you have better suggestions, please let me know.
