### PR TITLE
Add suggestions for improving reading level & joblint issues

### DIFF
--- a/jekyll/_includes/site/analysisfield.html
+++ b/jekyll/_includes/site/analysisfield.html
@@ -25,7 +25,7 @@
 
 <script type="text/x-template" data-template="suggestions">
   {#suggestions}
-    <p>{explanation} ({examples})</p>
+    <p><b>{examples}</b> - {explanation}</p>
   {/suggestions}
   {^suggestions}
   <p>Suggestions for improvement</p>

--- a/jekyll/_includes/site/analysisfield.html
+++ b/jekyll/_includes/site/analysisfield.html
@@ -9,7 +9,9 @@
     <p class="analysisTitle">Gender biased phrases</p>
     <div id="{id}-reading-output" event-id="{id}" data-control="readingLevelOutput" class="analysis"></div>
     <div id="{id}-count-output" event-id="{id}" data-control="countOutput" class="analysis"></div>
-    <p>Suggestions for Improvement</p>
+    <div id="{id}-suggestions" event-id="{id}" data-control="suggestionsOutput">
+      <p>Suggestions for improvement</p>
+    </div>
   </div>
 </script>
 
@@ -19,4 +21,13 @@
 
 <script type="text/x-template" data-template="issueCount">
   <p>{issueCount}</p>
+</script>
+
+<script type="text/x-template" data-template="suggestions">
+  {#suggestions}
+    <p>{explanation} ({examples})</p>
+  {/suggestions}
+  {^suggestions}
+  <p>Suggestions for improvement</p>
+  {/suggestions}
 </script>

--- a/jekyll/asset/script/main.js
+++ b/jekyll/asset/script/main.js
@@ -548,14 +548,24 @@
       var suggestions = [];
       if (text) {
         var ts = textstatistics(text);
-        var longWords = ts.listWordsWithFourOrMoreSyllables(text, false);
+        var longWords = ts.wordsWithFourOrMoreSyllablesList(text, false);
         if (longWords.length !== 0) {
           suggestions.push({
             "explanation": "Some words are very long (four or more syllables), try to replace with simpler words.",
             "examples": longWords
           });
         }
-        // maybe long sentences?
+        var longSentences = ts.sentencesOver25WordsList();
+        if (longSentences.length !== 0) {
+          var sentenceExamples = _.map(longSentences, function(sentence) {
+            return sentence.substring(0, 10) + "...";
+          });
+
+          suggestions.push({
+            "explanation": "At 25 words or more, sentences become difficult to read, try to shorten these or break them up.",
+            "examples": sentenceExamples
+          });
+        }
       }
       return suggestions;
     }

--- a/jekyll/asset/script/main.js
+++ b/jekyll/asset/script/main.js
@@ -68,6 +68,7 @@
             var results = joblint(inputValue);
             results.readingLevel = buildReadingLevel(element.value);
             results.suggestions = generateReadingLevelSuggestions(element.value); // try to combine with above method?
+            results.suggestions = rearrangeJobLintResults(results.issues, results.suggestions); // this whole bit could use a rewrite
             var lintId = generateLintId(results);
             var eventId = element.getAttributeNode("event-id").value;
             $document.trigger('lint-results-' + eventId, results);
@@ -112,7 +113,6 @@
 
       var eventId = element.getAttributeNode("event-id").value;
       $(document).on('lint-results-' + eventId, function (event, results) {
-        console.log(results.suggestions[0]);
         element.innerHTML = templates.suggestions.render({"suggestions" : results.suggestions});
         cuff(element);
       });
@@ -545,7 +545,7 @@
     }
 
     function generateReadingLevelSuggestions(text) {
-      var suggestions= [];
+      var suggestions = [];
       if (text) {
         var ts = textstatistics(text);
         var longWords = ts.listWordsWithFourOrMoreSyllables(text, false);
@@ -555,10 +555,21 @@
             "examples": longWords
           });
         }
-
-
+        // maybe long sentences?
       }
-      // console.log(suggestions);
+      return suggestions;
+    }
+
+    function rearrangeJobLintResults(issues, suggestions) {
+      var sexismIssues = _.filter(issues, function(i) {
+        return _.has(i.increment, 'sexism');
+      });
+      for (var i = 0; i < sexismIssues.length; i++) {
+        suggestions.push({
+          "explanation": sexismIssues[i].solution,
+          "examples": sexismIssues[i].occurrence
+        });
+      }
       return suggestions;
     }
 

--- a/jekyll/asset/script/main.js
+++ b/jekyll/asset/script/main.js
@@ -33,6 +33,7 @@
         cuff.controls.postInput = postInputControl;
         cuff.controls.countOutput = countOutputControl;
         cuff.controls.readingLevelOutput = readingLevelOutputControl;
+        cuff.controls.suggestionsOutput = suggestionsOutputControl;
         cuff.controls.freshStartButton = freshStartControl;
         cuff.controls.showTemplatesButton = showTemplatesControl;
         cuff.controls.pickTemplateButton = pickTemplateControl;
@@ -66,6 +67,7 @@
             var inputValue = element.value.replace(/\n/g, "<br>");
             var results = joblint(inputValue);
             results.readingLevel = buildReadingLevel(element.value);
+            results.suggestions = generateReadingLevelSuggestions(element.value); // try to combine with above method?
             var lintId = generateLintId(results);
             var eventId = element.getAttributeNode("event-id").value;
             $document.trigger('lint-results-' + eventId, results);
@@ -102,6 +104,16 @@
         };
 
         element.innerHTML = templates.readingLevel.render(readingLevelSummary);
+        cuff(element);
+      });
+    }
+
+    function suggestionsOutputControl(element) {
+
+      var eventId = element.getAttributeNode("event-id").value;
+      $(document).on('lint-results-' + eventId, function (event, results) {
+        console.log(results.suggestions[0]);
+        element.innerHTML = templates.suggestions.render({"suggestions" : results.suggestions});
         cuff(element);
       });
     }
@@ -530,6 +542,24 @@
       } else {
         return -1;
       }
+    }
+
+    function generateReadingLevelSuggestions(text) {
+      var suggestions= [];
+      if (text) {
+        var ts = textstatistics(text);
+        var longWords = ts.listWordsWithFourOrMoreSyllables(text, false);
+        if (longWords.length !== 0) {
+          suggestions.push({
+            "explanation": "Some words are very long (four or more syllables), try to replace with simpler words.",
+            "examples": longWords
+          });
+        }
+
+
+      }
+      // console.log(suggestions);
+      return suggestions;
     }
 
     function getSkillsEngineCompetencies (text, callback) {

--- a/jekyll/asset/script/main.js
+++ b/jekyll/asset/script/main.js
@@ -68,10 +68,10 @@
             var results = joblint(inputValue);
             results.readingLevel = buildReadingLevel(element.value);
             results.suggestions = generateReadingLevelSuggestions(element.value); // try to combine with above method?
-            results.suggestions = rearrangeJobLintResults(results.issues, results.suggestions); // this whole bit could use a rewrite
-            var lintId = generateLintId(results);
+            var finalResults = rearrangeJobLintResults(results); // this whole bit could use a rewrite
+            var lintId = generateLintId(finalResults);
             var eventId = element.getAttributeNode("event-id").value;
-            $document.trigger('lint-results-' + eventId, results);
+            $document.trigger('lint-results-' + eventId, finalResults);
         });
     }
 
@@ -570,17 +570,20 @@
       return suggestions;
     }
 
-    function rearrangeJobLintResults(issues, suggestions) {
-      var sexismIssues = _.filter(issues, function(i) {
+    function rearrangeJobLintResults(results) {
+      var finalResults = _.cloneDeep(results);
+      var sexismIssues = _.filter(finalResults.issues, function(i) {
         return _.has(i.increment, 'sexism');
       });
+
       for (var i = 0; i < sexismIssues.length; i++) {
-        suggestions.push({
+        finalResults.suggestions.push({
           "explanation": sexismIssues[i].solution,
           "examples": sexismIssues[i].occurrence
         });
       }
-      return suggestions;
+
+      return finalResults;
     }
 
     function getSkillsEngineCompetencies (text, callback) {

--- a/jekyll/asset/script/vendor/TextStatistics.js
+++ b/jekyll/asset/script/vendor/TextStatistics.js
@@ -94,6 +94,17 @@
 		return this.wordCount(text) / this.sentenceCount(text);
 	};
 
+	TextStatistics.prototype.sentencesOver25WordsList = function(text, countProperNouns) {
+		text = text ? cleanText(text) : this.text;
+		var longSentences = [], self = this;
+
+		text.replace(/([.?!])\s*(?=[A-Z])/g, "$1|").split("|").forEach(function(sentence) {
+			if (self.wordCount(sentence) >= 25) longSentences.push(sentence);
+		});
+
+		return longSentences;
+	};
+
 	TextStatistics.prototype.averageSyllablesPerWord = function(text) {
 		text = text ? cleanText(text) : this.text;
 		var syllableCount = 0, wordCount = this.wordCount(text), self = this;
@@ -125,7 +136,7 @@
 		return longWordCount;
 	};
 
-	TextStatistics.prototype.listWordsWithFourOrMoreSyllables = function(text, countProperNouns) {
+	TextStatistics.prototype.wordsWithFourOrMoreSyllablesList = function(text, countProperNouns) {
 		text = text ? cleanText(text) : this.text;
 		var longWords = [], self = this;
 

--- a/jekyll/asset/script/vendor/TextStatistics.js
+++ b/jekyll/asset/script/vendor/TextStatistics.js
@@ -115,13 +115,33 @@
 		text.split(/\s+/).forEach(function(word) {
 
 			// We don't count proper nouns or capitalised words if the countProperNouns attribute is set.
+			// Also don't count email addresses.
 			// Defaults to true.
-			if (!word.match(/^[A-Z]/) || countProperNouns) {
+			if ((!word.match(/^[A-Z]/) || countProperNouns) && !word.match(/@/)) {
 				if (self.syllableCount(word) > 2) longWordCount ++;
 			}
 		});
 
 		return longWordCount;
+	};
+
+	TextStatistics.prototype.listWordsWithFourOrMoreSyllables = function(text, countProperNouns) {
+		text = text ? cleanText(text) : this.text;
+		var longWords = [], self = this;
+
+		countProperNouns = countProperNouns === false ? false : true;
+
+		text.split(/\s+/).forEach(function(word) {
+
+			// We don't count proper nouns or capitalised words if the countProperNouns attribute is set.
+			// Also don't count email addresses.
+			// Defaults to true.
+			if ((!word.match(/^[A-Z]/) || countProperNouns) && !word.match(/@/)) {
+				if (self.syllableCount(word) > 3) longWords.push(word);
+			}
+		});
+
+		return longWords;
 	};
 
 	TextStatistics.prototype.percentageWordsWithThreeSyllables = function(text, countProperNouns) {

--- a/jekyll/asset/script/vendor/TextStatistics.js
+++ b/jekyll/asset/script/vendor/TextStatistics.js
@@ -19,6 +19,7 @@
 			.replace(/[,:;()\/&+]|\-\-/g, " ")				// Replace commas, hyphens etc (count them as spaces)
 			.replace(/[\.!?]/g, ".")					// Unify terminators
 			.replace(/^\s+/, "")						// Strip leading whitespace
+			.replace(/[\.]?(\w+)[\.]?(\w+)@(\w+)[\.](\w+)[\.]?/g, "$1$2@$3$4")	// strip periods in email addresses (so they remain counted as one word)
 			.replace(/[ ]*(\n|\r\n|\r)[ ]*/g, ".")	// Replace new lines with periods
 			.replace(/([\.])[\.]+/g, ".")			// Check for duplicated terminators
 			.replace(/[ ]*([\.])/g, ". ")				// Pad sentence terminators
@@ -28,7 +29,6 @@
 		if(text.slice(-1) != '.') {
 			text += "."; // Add final terminator, just in case it's missing.
 		}
-
 		return text;
 	}
 


### PR DESCRIPTION
@skcain you can see what I mean about displaying suggestions in this branch (right now it flags all the sexism prompts in joblint, plus 4+ syllable word). I figured for each thing there would be `examples` text and `explanation` text, where `examples` is what needs to be changed.

I'm probably not going to change that HTML much before merging, so if you want to work off of this branch feel free.

Closes #122 #111 
